### PR TITLE
Correção na autenticação junto ao serviço.

### DIFF
--- a/app/code/local/MOIP/Transparente/controllers/Adminhtml/OauthmoipController.php
+++ b/app/code/local/MOIP/Transparente/controllers/Adminhtml/OauthmoipController.php
@@ -113,10 +113,10 @@ class MOIP_Transparente_Adminhtml_OauthmoipController extends  Mage_Adminhtml_Co
 		$json_log = json_encode($data);
 		$api->generateLog($json_log, 'MOIP_Oauth.log');
 		
-			$store_id = $data['store_id'];
+			$store_id = $data['key'];
 
-			if($data['store_id']){
-				$store_code = $data['store_id'];
+			if($data['key']){
+				$store_code = $data['key'];
 			} else {
 				$store_code = 'default';
 			}


### PR DESCRIPTION
Ao fazer a autenticação junto à Moip, no controller MOIP_Transparente_Adminhtml_OauthmoipController no método OauthAction(), ele recebe os parâmetros do request na variável $data. Na linha 116 é definida a variável $store_id baseado no indice "store_id" que teoricamente viria do request. Porém o request retorna "key" e não "store_id", logo o PHP apresenta erro de undefined_index.

Foram substituídas as definições das variáveis que utilizavam o indice "store_id" por "key" e tudo funcionou adequadamente.